### PR TITLE
Orbit controls configuration

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -483,6 +483,9 @@ class VR extends Plugin {
           this.log('no vr displays found going to use OrbitControls');
           this.controls3d = new OrbitControls(this.camera, this.renderedCanvas);
           this.controls3d.target.set(0, 0, -1);
+          this.controls3d.enableZoom = false;
+          this.controls3d.enablePan = false;
+          this.controls3d.rotateSpeed = -0.5;
         }
         this.animationFrameId_ = this.requestAnimationFrame(this.animate_);
       });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -372,7 +372,7 @@ class VR extends Plugin {
     this.videoTexture.magFilter = THREE.LinearFilter;
     this.videoTexture.format = THREE.RGBFormat;
 
-    this.movieMaterial = new THREE.MeshBasicMaterial({ map: this.videoTexture, overdraw: true, side: THREE.DoubleSide });
+    this.movieMaterial = new THREE.MeshBasicMaterial({ map: this.videoTexture, overdraw: true, side: THREE.FrontSide });
 
     this.changeProjection_(this.currentProjection_);
 


### PR DESCRIPTION
fixes inverted controls when there is no VR Display, and prevent user from panning and zooming
also set the material to one side rendering only